### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         go:


### PR DESCRIPTION
Potential fix for [https://github.com/peczenyj/isnil/security/code-scanning/2](https://github.com/peczenyj/isnil/security/code-scanning/2)

To fix the problem, explicitly define the minimal `GITHUB_TOKEN` permissions required by this workflow. Since the job only needs to read the repository to check out code and run tests, and then uploads coverage to an external service using a separate secret (`CODECOV_TOKEN`), it can safely run with read‑only repository permissions.

The best fix without changing functionality is to add a `permissions:` block at the job level under `jobs.build` (or at the root; here we’ll apply it to this job only). Set `contents: read`, which is the minimal permission necessary for `actions/checkout` and typical read‑only operations. No additional scopes (such as `pull-requests: write`) are needed because the workflow does not post comments or modify PRs.

Concretely, in `.github/workflows/go.yml`, under `jobs:`, inside the `build:` job, add:

```yaml
permissions:
  contents: read
```

aligned correctly with `runs-on:` so that it applies to that job. No imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
